### PR TITLE
Add link to "official" docs.julialang styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Style.jl
 ========
 
+UPDATE: Please see the Julia Docs Style Guide: https://docs.julialang.org/en/stable/manual/style-guide/ <br> This repository hasn't been updated in many years. Where it differs, prefer the Julia Docs guide, above.
+------------
+
 This document lays out, in a very rough draft form, the style guidelines
 for Julia programming that I've started to impose on myself. I'd ask that
 anyone making contributions to my packages consider following these


### PR DESCRIPTION
:) Idk if the wording I used was too intense, feel free to change it. But I figured it would be useful to link to the official style guide from here!

I came here from https://discourse.julialang.org/t/is-there-a-pep8-for-julia/1433/3.

There is still a lot of stuff covered in this document that's not covered in the official guide (such as whitespace, etc), so it seems nice to keep this around. But there are also points where the official guide gives the opposite recommendation (prefer `foo(x, y)` over `foo(x::Real, y::Real)` or `foo(x::Any, y::Any)`). I assume that the recommendations have simply evolved over time.

:) Thanks!