### PR TITLE
fix URL of Style Guide in Julia docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Style.jl
 ========
 
-UPDATE: Please see the Julia Docs Style Guide: https://docs.julialang.org/en/stable/manual/style-guide/ <br> This repository hasn't been updated in many years. Where it differs, prefer the Julia Docs guide, above.
+UPDATE: Please see the Julia Docs Style Guide: https://docs.julialang.org/en/v1/manual/style-guide/ <br> This repository hasn't been updated in many years. Where it differs, prefer the Julia Docs guide, above.
 ------------
 
 This document lays out, in a very rough draft form, the style guidelines


### PR DESCRIPTION
I got 404 after Julia 1.0 release